### PR TITLE
Fix Dependabot security vulnerabilities

### DIFF
--- a/red-team-exercises/Cargo.toml
+++ b/red-team-exercises/Cargo.toml
@@ -16,20 +16,20 @@ clap = { version = "4.0", features = ["derive"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 base64 = "0.21"
-jsonwebtoken = "8.0"
+jsonwebtoken = "9.0"
 sha2 = "0.10"
 hmac = "0.12"
 url = "2.3"
-redis = "0.23"
+redis = "0.32"
 futures = "0.3"
 prometheus = "0.13"
-hyper = "0.14"
+hyper = "1.0"
 # hyper-tls removed to avoid native-tls dependency
-trust-dns-resolver = "0.23"
+trust-dns-resolver = "0.24"
 pem = "3.0"
 # rsa crate removed due to RUSTSEC-2023-0071 vulnerability
 x509-parser = "0.15"
-pprof = { version = "0.11", features = ["criterion", "flamegraph"] }
+pprof = { version = "0.13", features = ["criterion", "flamegraph"] }
 criterion = { version = "0.5", features = ["html_reports"] }
 pretty_assertions = "1.4"
 colored = "2.0"


### PR DESCRIPTION
Fixes #10

Update dependencies to secure versions in red-team-exercises/Cargo.toml:

- jsonwebtoken: 8.0 → 9.0 (addresses JWT vulnerabilities)
- redis: 0.23 → 0.32 (addresses security issues)
- hyper: 0.14 → 1.0 (addresses HTTP vulnerabilities)
- trust-dns-resolver: 0.23 → 0.24 (addresses DNS vulnerabilities)
- pprof: 0.11 → 0.13 (addresses profiling vulnerabilities)

These updates resolve multiple Dependabot alerts for both moderate and low severity vulnerabilities.

Generated with [Claude Code](https://claude.ai/code)