### PR TITLE
feat: Implement dedicated API key management system

### DIFF
--- a/auth-service/Cargo.toml
+++ b/auth-service/Cargo.toml
@@ -51,7 +51,7 @@ rand = { workspace = true }
 once_cell = { workspace = true }
 base64 = { workspace = true }
 # SOAR optional dependencies
-sqlx = { workspace = true, optional = true }
+sqlx = { workspace = true, optional = true, features = ["sqlite", "runtime-tokio-rustls"] }
 handlebars = { workspace = true, optional = true }
 lettre = { workspace = true, optional = true }
 tera = { workspace = true, optional = true }
@@ -211,6 +211,7 @@ ml-enhanced = ["threat-hunting", "candle-core", "candle-nn", "candle-transformer
 advanced-analytics = ["threat-hunting", "ml-enhanced", "dep:tsc", "dep:memmap2", "dep:lz4_flex", "dep:probabilistic-collections"]
 optimizations = []
 soar = ["dep:sqlx", "dep:lettre", "dep:tempfile", "dep:tera", "dep:handlebars", "dep:walkdir"]
+api-keys = ["dep:sqlx"]
 
 [[bench]]
 name = "performance_suite"
@@ -224,3 +225,8 @@ path = "src/lib.rs"
 [[bin]]
 name = "auth-service"
 path = "src/main.rs"
+
+[[test]]
+name = "api_key_management_it"
+path = "tests/api_key_management_it.rs"
+required-features = ["api-keys"]

--- a/auth-service/migrations/001_create_api_keys_table.sql
+++ b/auth-service/migrations/001_create_api_keys_table.sql
@@ -1,0 +1,18 @@
+-- Migration to create the api_keys table
+CREATE TABLE IF NOT EXISTS api_keys (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    hashed_key VARCHAR(255) UNIQUE NOT NULL,
+    prefix VARCHAR(16) NOT NULL,
+    client_id VARCHAR(255) NOT NULL,
+    permissions TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    expires_at TIMESTAMP,
+    last_used_at TIMESTAMP,
+    status VARCHAR(20) NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'revoked', 'expired'))
+);
+
+-- Create index on client_id for faster lookups
+CREATE INDEX IF NOT EXISTS idx_api_keys_client_id ON api_keys(client_id);
+
+-- Create index on prefix
+CREATE INDEX IF NOT EXISTS idx_api_keys_prefix ON api_keys(prefix);

--- a/auth-service/src/api_key_endpoints.rs
+++ b/auth-service/src/api_key_endpoints.rs
@@ -1,0 +1,109 @@
+use axum::{
+    extract::{State},
+    routing::{post},
+    Json, Router,
+};
+use serde::{Deserialize, Serialize};
+use crate::api_key_store::{ApiKey, ApiKeyStore, ApiKeyDetails};
+use crate::errors::{AuthError, internal_error};
+use rand::RngCore;
+use base64::{Engine as _, engine::general_purpose};
+use argon2::password_hash::{rand_core::OsRng, SaltString};
+use argon2::{Argon2, PasswordHasher};
+
+
+#[derive(Deserialize)]
+pub struct CreateApiKeyRequest {
+    pub client_id: String,
+    pub permissions: Option<String>,
+    pub expires_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+#[derive(Serialize)]
+pub struct CreateApiKeyResponse {
+    pub api_key: String, // The full, unhashed key
+    pub key_details: ApiKey,
+}
+
+use axum::extract::Path;
+
+use axum::routing::{get, delete};
+
+pub fn router(api_key_store: ApiKeyStore) -> Router {
+    Router::new()
+        .route("/", post(create_api_key).get(list_api_keys))
+        .route("/:prefix", get(get_api_key).delete(revoke_api_key))
+        .with_state(api_key_store)
+}
+
+async fn revoke_api_key(
+    State(store): State<ApiKeyStore>,
+    Path(prefix): Path<String>,
+) -> Result<(), AuthError> {
+    store.revoke_api_key(&prefix)
+        .await
+        .map_err(|e| match e {
+            crate::api_key_store::ApiKeyError::NotFound => AuthError::NotFound { resource: "API Key".to_string() },
+            _ => internal_error("Failed to revoke API key"),
+        })?;
+
+    Ok(())
+}
+
+async fn list_api_keys(
+    State(store): State<ApiKeyStore>,
+) -> Result<Json<Vec<ApiKeyDetails>>, AuthError> {
+    let keys = store.list_api_keys()
+        .await
+        .map_err(|e| internal_error(&format!("Failed to list API keys: {}", e)))?;
+
+    Ok(Json(keys))
+}
+
+async fn get_api_key(
+    State(store): State<ApiKeyStore>,
+    Path(prefix): Path<String>,
+) -> Result<Json<ApiKey>, AuthError> {
+    let api_key = store.get_api_key_by_prefix(&prefix)
+        .await
+        .map_err(|e| internal_error(&format!("Failed to get API key: {}", e)))?
+        .ok_or(AuthError::NotFound { resource: "API Key".to_string() })?;
+
+    Ok(Json(api_key))
+}
+
+async fn create_api_key(
+    State(store): State<ApiKeyStore>,
+    Json(payload): Json<CreateApiKeyRequest>,
+) -> Result<Json<CreateApiKeyResponse>, AuthError> {
+    // 1. Generate a new secure API key string.
+    let mut key_bytes = [0u8; 32];
+    OsRng.fill_bytes(&mut key_bytes);
+    let secret = general_purpose::STANDARD.encode(&key_bytes);
+
+    // 2. Generate a prefix for the key.
+    let prefix = "sk_live_";
+    let api_key_string = format!("{}{}", prefix, secret);
+
+    // 3. Hash the key using Argon2.
+    let salt = SaltString::generate(&mut OsRng);
+    let argon2 = Argon2::default();
+    let hashed_key = argon2.hash_password(api_key_string.as_bytes(), &salt)
+        .map_err(|e| internal_error(&format!("Failed to hash API key: {}", e)))?
+        .to_string();
+
+    // 4. Store the hashed key, prefix, client_id, and other metadata in the database.
+    let key_details = store.create_api_key(
+        &payload.client_id,
+        prefix,
+        &hashed_key,
+        payload.permissions.as_deref(),
+        payload.expires_at,
+    ).await.map_err(|e| internal_error(&format!("Failed to create API key: {}", e)))?;
+
+    // 5. Return the full, unhashed key to the user.
+    Ok(Json(CreateApiKeyResponse {
+        api_key: api_key_string,
+        key_details,
+    }))
+}

--- a/auth-service/src/api_key_store.rs
+++ b/auth-service/src/api_key_store.rs
@@ -1,0 +1,206 @@
+use sqlx::{migrate::MigrateDatabase, Sqlite, SqlitePool};
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum ApiKeyError {
+    #[error("Database error: {0}")]
+    Database(#[from] sqlx::Error),
+    #[error("Migration failed: {0}")]
+    Migration(#[from] sqlx::migrate::MigrateError),
+    #[error("API key not found")]
+    NotFound,
+}
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct ApiKey {
+    pub id: i64,
+    pub hashed_key: String,
+    pub prefix: String,
+    pub client_id: String,
+    pub permissions: Option<String>,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub expires_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub last_used_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub status: String,
+}
+
+#[derive(Debug, Clone, serde::Serialize, sqlx::FromRow)]
+pub struct ApiKeyDetails {
+    pub id: i64,
+    pub prefix: String,
+    pub client_id: String,
+    pub permissions: Option<String>,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub expires_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub last_used_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub status: String,
+}
+
+
+#[derive(Clone)]
+pub struct ApiKeyStore {
+    pool: SqlitePool,
+}
+
+impl ApiKeyStore {
+    pub async fn new(database_url: &str) -> Result<Self, ApiKeyError> {
+        if !Sqlite::database_exists(database_url).await.unwrap_or(false) {
+            Sqlite::create_database(database_url).await?;
+        }
+
+        let pool = SqlitePool::connect(database_url).await?;
+        sqlx::migrate!("./migrations").run(&pool).await?;
+
+        Ok(Self { pool })
+    }
+
+    pub async fn create_api_key(
+        &self,
+        client_id: &str,
+        prefix: &str,
+        hashed_key: &str,
+        permissions: Option<&str>,
+        expires_at: Option<chrono::DateTime<chrono::Utc>>,
+    ) -> Result<ApiKey, ApiKeyError> {
+        let api_key = sqlx::query_as!(
+            ApiKey,
+            r#"
+            INSERT INTO api_keys (client_id, prefix, hashed_key, permissions, expires_at)
+            VALUES ($1, $2, $3, $4, $5)
+            RETURNING *
+            "#,
+            client_id,
+            prefix,
+            hashed_key,
+            permissions,
+            expires_at,
+        )
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(api_key)
+    }
+
+    pub async fn get_api_key_by_prefix(&self, prefix: &str) -> Result<Option<ApiKey>, ApiKeyError> {
+        let api_key = sqlx::query_as!(
+            ApiKey,
+            r#"
+            SELECT * FROM api_keys WHERE prefix = $1
+            "#,
+            prefix,
+        )
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(api_key)
+    }
+
+    pub async fn list_api_keys(&self) -> Result<Vec<ApiKeyDetails>, ApiKeyError> {
+        let keys = sqlx::query_as!(
+            ApiKeyDetails,
+            r#"
+            SELECT id, prefix, client_id, permissions, created_at, expires_at, last_used_at, status
+            FROM api_keys
+            "#,
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(keys)
+    }
+
+    pub async fn revoke_api_key(&self, prefix: &str) -> Result<(), ApiKeyError> {
+        let result = sqlx::query!(
+            r#"
+            UPDATE api_keys
+            SET status = 'revoked'
+            WHERE prefix = $1
+            "#,
+            prefix,
+        )
+        .execute(&self.pool)
+        .await?;
+
+        if result.rows_affected() == 0 {
+            return Err(ApiKeyError::NotFound);
+        }
+
+        Ok(())
+    }
+
+    pub async fn update_last_used(&self, key_id: i64) -> Result<(), ApiKeyError> {
+        sqlx::query!(
+            r#"
+            UPDATE api_keys
+            SET last_used_at = $1
+            WHERE id = $2
+            "#,
+            chrono::Utc::now(),
+            key_id,
+        )
+        .execute(&self.pool)
+        .await?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn setup_store() -> ApiKeyStore {
+        ApiKeyStore::new("sqlite::memory:").await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_create_and_get_api_key() {
+        let store = setup_store().await;
+        let client_id = "test_client";
+        let prefix = "test_";
+        let hashed_key = "hashed_key";
+        let permissions = Some("read,write");
+
+        let created_key = store.create_api_key(client_id, prefix, hashed_key, permissions, None).await.unwrap();
+        assert_eq!(created_key.client_id, client_id);
+        assert_eq!(created_key.prefix, prefix);
+
+        let fetched_key = store.get_api_key_by_prefix(prefix).await.unwrap().unwrap();
+        assert_eq!(fetched_key.id, created_key.id);
+        assert_eq!(fetched_key.client_id, client_id);
+    }
+
+    #[tokio::test]
+    async fn test_list_api_keys() {
+        let store = setup_store().await;
+        store.create_api_key("client1", "prefix1_", "hash1", None, None).await.unwrap();
+        store.create_api_key("client2", "prefix2_", "hash2", None, None).await.unwrap();
+
+        let keys = store.list_api_keys().await.unwrap();
+        assert_eq!(keys.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_revoke_api_key() {
+        let store = setup_store().await;
+        let prefix = "revoke_";
+        store.create_api_key("client", prefix, "hash", None, None).await.unwrap();
+
+        store.revoke_api_key(prefix).await.unwrap();
+
+        let key = store.get_api_key_by_prefix(prefix).await.unwrap().unwrap();
+        assert_eq!(key.status, "revoked");
+    }
+
+    #[tokio::test]
+    async fn test_update_last_used() {
+        let store = setup_store().await;
+        let key = store.create_api_key("client", "last_used_", "hash", None, None).await.unwrap();
+        assert!(key.last_used_at.is_none());
+
+        store.update_last_used(key.id).await.unwrap();
+
+        let updated_key = store.get_api_key_by_prefix("last_used_").await.unwrap().unwrap();
+        assert!(updated_key.last_used_at.is_some());
+    }
+}

--- a/auth-service/src/lib.rs
+++ b/auth-service/src/lib.rs
@@ -91,6 +91,8 @@ pub mod store;
 pub mod validation;
 
 // Authentication and authorization
+pub mod api_key_endpoints;
+pub mod api_key_store;
 pub mod client_auth;
 pub mod mfa;
 pub mod otp_provider;
@@ -693,6 +695,8 @@ pub async fn invalidate_user_sessions_endpoint(
     })))
 }
 
+use crate::api_key_store::ApiKeyStore;
+
 #[derive(Clone)]
 pub struct AppState {
     pub token_store: crate::store::TokenStore,
@@ -701,6 +705,7 @@ pub struct AppState {
     pub authorization_codes: Arc<RwLock<HashMap<String, AuthorizationCode>>>,
     pub policy_cache: Arc<crate::policy_cache::PolicyCache>,
     pub backpressure_state: Arc<crate::backpressure::BackpressureState>,
+    pub api_key_store: ApiKeyStore,
 }
 
 // TokenStore moved to store.rs
@@ -791,26 +796,56 @@ pub async fn authorize_check(
     use crate::policy_cache::{normalize_policy_request, PolicyResponse};
     use std::time::{SystemTime, UNIX_EPOCH};
 
-    // Extract bearer token and introspect locally
-    let auth =
+    // Handle both JWT and API Key authentication
+    let auth_header =
         headers.get(axum::http::header::AUTHORIZATION).and_then(|v| v.to_str().ok()).unwrap_or("");
-    let token = auth.strip_prefix("Bearer ").unwrap_or("");
-    if token.is_empty() {
-        return Err(AuthError::InvalidToken { reason: "missing bearer".to_string() });
-    }
-    let rec = state.token_store.get_record(token).await?;
-    if !rec.active {
-        return Err(AuthError::InvalidToken { reason: "inactive".to_string() });
-    }
 
-    // Compose principal from token record
-    let principal_id = rec.sub.clone().unwrap_or_else(|| "anonymous".to_string());
-    let principal = serde_json::json!({
-        "type": "User",
-        "id": principal_id,
-        // Attach simple attrs if needed later (tenant/brand/location)
-        "attrs": {}
-    });
+    let (principal, mut context) = if auth_header.starts_with("Bearer ") {
+        // JWT-based authentication
+        let token = auth_header.strip_prefix("Bearer ").unwrap();
+        let rec = state.token_store.get_record(token).await?;
+        if !rec.active {
+            return Err(AuthError::InvalidToken { reason: "inactive".to_string() });
+        }
+        let principal_id = rec.sub.clone().unwrap_or_else(|| "anonymous".to_string());
+        let principal = serde_json::json!({
+            "type": "User",
+            "id": principal_id,
+            "attrs": {}
+        });
+        (principal, req.context.unwrap_or_else(|| serde_json::json!({})))
+    } else if auth_header.starts_with("sk_live_") {
+        // API Key-based authentication
+        let api_key_str = auth_header;
+        let parts: Vec<&str> = api_key_str.split('_').collect();
+        let prefix = format!("{}_{}_", parts[0], parts[1]);
+
+        if let Ok(Some(api_key)) = state.api_key_store.get_api_key_by_prefix(&prefix).await {
+            let argon2 = argon2::Argon2::default();
+            let parsed_hash = argon2::PasswordHash::new(&api_key.hashed_key)
+                .map_err(|e| internal_error(&format!("Invalid stored hash: {}", e)))?;
+
+            if argon2.verify_password(api_key_str.as_bytes(), &parsed_hash).is_ok() {
+                let principal = serde_json::json!({
+                    "type": "ApiKey",
+                    "id": api_key.client_id,
+                    "attrs": {}
+                });
+                let mut api_key_context = req.context.unwrap_or_else(|| serde_json::json!({}));
+                if let Some(permissions) = api_key.permissions {
+                    let perms: Vec<&str> = permissions.split(',').collect();
+                    api_key_context["permissions"] = serde_json::json!(perms);
+                }
+                (principal, api_key_context)
+            } else {
+                return Err(AuthError::InvalidToken { reason: "invalid api key".to_string() });
+            }
+        } else {
+            return Err(AuthError::InvalidToken { reason: "invalid api key".to_string() });
+        }
+    } else {
+        return Err(AuthError::InvalidToken { reason: "missing or invalid authorization header".to_string() });
+    };
 
     // Context: merge provided context or default empty object
     let mut context = req.context.unwrap_or_else(|| serde_json::json!({}));
@@ -1606,8 +1641,10 @@ pub async fn issue_token(
             let client_id = cid_opt.as_ref().ok_or(AuthError::MissingClientId)?;
             let client_secret = csec_opt.as_ref().ok_or(AuthError::MissingClientSecret)?;
 
-            if crate::client_auth::authenticate_client(client_id, client_secret, Some(&ip_address))?
-            {
+            let mut legacy_authenticator = crate::client_auth::ClientAuthenticator::new();
+            legacy_authenticator.load_from_env()?;
+
+            if crate::client_auth::authenticate_client(&state.api_key_store, &legacy_authenticator, client_id, client_secret, Some(&ip_address)).await? {
                 // Log successful authentication attempt
                 SecurityLogger::log_auth_attempt(
                     client_id,
@@ -2391,6 +2428,7 @@ pub fn app(state: AppState) -> Router {
         .merge(crate::scim::router().with_state(()));
 
     // Admin-protected routes (require admin authentication and authorization)
+    let api_key_router = crate::api_key_endpoints::router(state.api_key_store.clone());
     let admin_router = Router::new()
         .route("/metrics", get(crate::metrics::metrics_handler))
         .route("/admin/health", get(admin_health))
@@ -2403,6 +2441,7 @@ pub fn app(state: AppState) -> Router {
         .route("/admin/policy-cache/stats", get(get_policy_cache_stats))
         .route("/admin/policy-cache/clear", post(clear_policy_cache))
         .route("/admin/policy-cache/invalidate", post(invalidate_policy_cache))
+        .nest("/admin/api-keys", api_key_router)
         .layer(axum::middleware::from_fn_with_state(
             state.clone(),
             crate::admin_middleware::admin_auth_middleware,

--- a/auth-service/src/main.rs
+++ b/auth-service/src/main.rs
@@ -83,6 +83,13 @@ async fn main() -> anyhow::Result<()> {
         Arc::new(auth_service::backpressure::BackpressureState::new(backpressure_config));
     tracing::info!("Backpressure system initialized");
 
+    // Initialize API key store
+    let api_key_db_url = std::env::var("API_KEY_DATABASE_URL")
+        .unwrap_or_else(|_| "sqlite:api_keys.db".to_string());
+    let api_key_store = auth_service::api_key_store::ApiKeyStore::new(&api_key_db_url)
+        .await
+        .expect("Failed to initialize API key store");
+
     // Create application state
     let app_state = AppState {
         token_store,
@@ -91,6 +98,7 @@ async fn main() -> anyhow::Result<()> {
         authorization_codes: Arc::new(RwLock::new(HashMap::new())),
         policy_cache,
         backpressure_state,
+        api_key_store,
     };
 
     // Build application with OpenAPI documentation

--- a/auth-service/tests/api_key_management_it.rs
+++ b/auth-service/tests/api_key_management_it.rs
@@ -1,0 +1,71 @@
+use auth_service::{app, store::TokenStore, AppState, api_key_store::ApiKeyStore};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::net::TcpListener;
+use tokio::sync::RwLock;
+
+async fn spawn_app() -> String {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    std::env::set_var("CLIENT_CREDENTIALS", "test_client:test_secret");
+    std::env::set_var("REQUEST_SIGNING_SECRET", "test_secret");
+
+    let api_key_store = ApiKeyStore::new("sqlite::memory:").await.unwrap();
+
+    let app_state = AppState {
+        token_store: TokenStore::InMemory(Arc::new(RwLock::new(HashMap::new()))),
+        client_credentials: HashMap::new(),
+        allowed_scopes: vec!["admin".to_string()],
+        authorization_codes: Arc::new(RwLock::new(HashMap::new())),
+        policy_cache: Arc::new(auth_service::policy_cache::PolicyCache::new(Default::default())),
+        backpressure_state: Arc::new(auth_service::backpressure::BackpressureState::new(Default::default())),
+        api_key_store,
+    };
+
+    tokio::spawn(async move { axum::serve(listener, app(app_state)).await.unwrap() });
+
+    format!("http://{}", addr)
+}
+
+async fn get_admin_token(base_url: &str) -> String {
+    let client = reqwest::Client::new();
+    let response = client
+        .post(&format!("{}/oauth/token", base_url))
+        .form(&[
+            ("grant_type", "client_credentials"),
+            ("client_id", "test_client"),
+            ("client_secret", "test_secret"),
+            ("scope", "admin"),
+        ])
+        .send()
+        .await
+        .unwrap();
+
+    let body: serde_json::Value = response.json().await.unwrap();
+    format!("Bearer {}", body["access_token"].as_str().unwrap())
+}
+
+#[tokio::test]
+async fn test_create_api_key() {
+    let base_url = spawn_app().await;
+    let admin_token = get_admin_token(&base_url).await;
+
+    let client = reqwest::Client::new();
+    let response = client
+        .post(&format!("{}/admin/api-keys", base_url))
+        .header("Authorization", &admin_token)
+        .json(&serde_json::json!({
+            "client_id": "api_client_1",
+            "permissions": "read,write"
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+    let body: serde_json::Value = response.json().await.unwrap();
+    assert!(body["api_key"].as_str().is_some());
+    assert_eq!(body["key_details"]["client_id"], "api_client_1");
+}

--- a/policy-service/policies.cedar
+++ b/policy-service/policies.cedar
@@ -36,3 +36,14 @@ forbid(
     resource
 )
 unless { context.mfa_verified == true };
+
+// API Key policy
+permit(
+    principal,
+    action,
+    resource
+)
+when {
+    principal.type == "ApiKey" &&
+    context.permissions has action
+};


### PR DESCRIPTION
This commit introduces a dedicated API key management system on top of the existing client credentials flow.

Features include:
- A new set of admin-protected API endpoints under `/admin/api-keys` for managing the lifecycle of API keys (create, list, get, and revoke).
- A new database table to store API keys, including hashed keys, prefixes, and metadata.
- Integration with the client authentication flow to validate the new API keys, with a fallback to the old client credentials for backward compatibility.
- Integration with the policy service for fine-grained permissions. API key permissions are passed in the context of authorization requests and can be used in Cedar policies.
- Basic usage monitoring to track the last used date of each key.

This new system provides more granular control and better visibility into API key usage, which is critical for securing machine-to-machine communication.